### PR TITLE
Use camelCase for clip and fill rules

### DIFF
--- a/src/Logo.tsx
+++ b/src/Logo.tsx
@@ -6,7 +6,7 @@ export function Logo({ color = 'black', ...props }) {
       <rect x="280" y="560" width="240" height="240" fill="inherit" />
       <rect x="280" y="280" width="240" height="240" fill="inherit" />
       <rect y="280" width="240" height="240" fill="inherit" />
-      <path fill-rule="evenodd" clip-rule="evenodd" d="M560 0H280V240H560V520H800V0H560Z" fill="inherit" />
+      <path fillRule="evenodd" clipRule="evenodd" d="M560 0H280V240H560V520H800V0H560Z" fill="inherit" />
     </svg>
   )
 }


### PR DESCRIPTION
Otherwise we get react warnings complaining about `clip-rule` and `fill-rule`.
